### PR TITLE
Don't mine areas of size 1 or less

### DIFF
--- a/src/main/java/me/swipez/chunkminer/ChunkMine.java
+++ b/src/main/java/me/swipez/chunkminer/ChunkMine.java
@@ -53,6 +53,9 @@ public class ChunkMine implements Listener {
                 bacr = 13;
             }
             List<Block> area = getBlocks(e, bup, bout, bacr);
+            if (area.size() <= 1) {
+                return;
+            }
 
             for (Block b : area) {
                 if (b.getType() != Material.BEDROCK && b.getType() != Material.LAVA && b.getType() != Material.WATER && b.getType() != Material.AIR) {


### PR DESCRIPTION
At the moment, when the mining size is 0 in all directions (i.e. no special pickaxes are being used), the origin block from BlockBreakEvent#getBlock() is still added to the area and broken with Block#breakNaturally(). This causes inconsistencies with any event listeners called after ChunkMiner because the type is not as expected despite ChunkMiner not directly changing the outcome of the event.

This was made clear with [VeinMiner](https://www.spigotmc.org/resources/veinminer.12038/) installed. It doesn't at all function when ChunkMiner is installed. This PR fixes this incompatibility.